### PR TITLE
release: Update Python version and project version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,6 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
-      id-token: write
       contents: read
 
     steps:
@@ -21,7 +20,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Install build tools
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "perch-py"
-version = "0.1.0"
+version = "0.1.1"
 description = "Perch is a developer-friendly CLI tool for scaffolding MCP HexLayer Architecture projects using clean structure and modular design."
 readme = "README.md"
 authors = [


### PR DESCRIPTION
Update the Python version in the publish workflow to 3.12. Increment the project version in `pyproject.toml` to 0.1.1. Remove unnecessary `id-token: write` permission from publish workflow.